### PR TITLE
This commit fixes the "NotReady" status of the Master Node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ cd /vagrant/ansible/deployments/helm
 helm install --name xxx .
 ```
 
-There is also a policy deployed which rejects any connections from sidecars to frontends. 
-
 <img src="https://github.com/zepptron/kubeadm-vagrant-ansible/blob/master/temp/vag.jpg?raw=true" width="800">
 
 ## Protips
@@ -52,9 +50,9 @@ There is this one user called "zepp" (default-pw: wurst) which is able to intera
 <img src="https://github.com/zepptron/kubeadm-vagrant-ansible/blob/master/temp/k-node.jpg?raw=true" width="400">
 
 ### Working fast
-the command `k` is your friend. It's the alias for `kubectl` because you will be angry when you always have to type _k u b e c t l_ ... followed by a namespace :)
+the command `k` is your friend. It's the alias for `kubectl` because you will be angry when you always have to type _k u b e c t l_ ... followed by a namespace etc :)
 
-So if you want to work in a specific namespace and you are annoyed of always typing `kubectl -n kube-public get pods -o wide` just adjust the _.bashrc_ file to your needs and it will be `k get pods -o wide`! I've already covered the standard namespaces, you just have to type `k-pub` (kube-public), `k-sys` (kube-system) or `k-def` (default) to work in a specific namespace. So when everything is installed and you login as "zepp", try the following:
+So if you want to work in a specific namespace and you are annoyed of always typing `kubectl -n kube-public get pods -o wide` just adjust the _.bashrc_ file to your needs and it will be `k get pods -o wide`! I've already covered the standard namespaces, you just have to type `k-pub` (kube-public), `k-sys` (kube-system) or `k-def` (default) to work in a specific namespace. So when everything is installed, try the following:
 
 ```
 k-sys
@@ -64,9 +62,6 @@ k-nodes
 
 This also works for deploying stuff etc, it's just an alias.
 
-## Todos
-- add helm
-- integrate HA-features (check the branches)
 
 ## Proxy - DEPRECATED
 By default the proxy settings are turned off. If you need to fight with a proxy, enable and configure it in the Vagrantfile. It's defined at the top:
@@ -75,4 +70,4 @@ $proxy = false		# true or false
 $proxy_url = "http://proxy.com:port"	# enter proxy URL here!
 ```
 
-Proxysupport won't be tested anymore. Sorry.
+**Proxysupport won't be tested anymore. Sorry.**

--- a/ansible/deployments/helm/templates/policy.yaml
+++ b/ansible/deployments/helm/templates/policy.yaml
@@ -1,15 +1,15 @@
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ .Values.policy.name }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ .Values.webDeployment.name }}
-      role: {{ .Values.policy.hitlabel }}
-  ingress:
-  - from:
-      - podSelector:
-          matchLabels:
-            app: {{ .Values.backendDeployment.name }}
-            role: {{ .Values.policy.allowlabel }}
+#kind: NetworkPolicy
+#apiVersion: networking.k8s.io/v1
+#metadata:
+#  name: {{ .Values.policy.name }}
+#spec:
+#  podSelector:
+#    matchLabels:
+#      app: {{ .Values.webDeployment.name }}
+#      role: {{ .Values.policy.hitlabel }}
+#  ingress:
+#  - from:
+#      - podSelector:
+#          matchLabels:
+#            app: {{ .Values.backendDeployment.name }}
+#            role: {{ .Values.policy.allowlabel }}

--- a/ansible/deployments/sys/calico.yml
+++ b/ansible/deployments/sys/calico.yml
@@ -166,11 +166,13 @@ spec:
         k8s-app: calico-node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
       serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.


### PR DESCRIPTION
There was a wrong (deprecated) tolerationsetting in the Daemonset. This is now fixed.
Also the Networkpolicy is deactivated by default now.

- added correct taint to run calico on master
- removed policy as default
- updated readme